### PR TITLE
[fix] Fix the bug of absolute height for h1 locomotion policy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -123,5 +123,8 @@ work_dirs/
 /asset
 /assets
 
+# user scripts
+/scripts
+
 # sphinx build dir
 docs/en/_build

--- a/demo/configs/h1_house.yaml
+++ b/demo/configs/h1_house.yaml
@@ -24,5 +24,7 @@ tasks:
     - name: "move_with_keyboard"
     - name: "web_chat"
     sensor_params:
+    - name: "camera"
+      enable: false
     - name: "tp_camera"
       enable: false

--- a/grutopia_extension/controllers/humanoid_move_by_speed_controller.py
+++ b/grutopia_extension/controllers/humanoid_move_by_speed_controller.py
@@ -130,7 +130,9 @@ class HumanoidMoveBySpeedController(BaseController):
         joint_pos -= default_dof_pos
 
         base_height = base_pose_w[0][2]
-        heights = np.clip(base_height - 0.5 - np.zeros(121), -1., 1.) * 5.0
+        ankle_height = self.robot.get_ankle_height()
+        relative_base_height = base_height - ankle_height
+        heights = np.clip(relative_base_height - 0.5 - np.zeros(121), -1., 1.) * 5.0
 
         # Set action command.
         tracking_command = np.array([forward_speed, lateral_speed, rotation_speed, 0.0], dtype=np.float32)

--- a/grutopia_extension/robots/humanoid.py
+++ b/grutopia_extension/robots/humanoid.py
@@ -205,12 +205,18 @@ class HumanoidRobot(BaseRobot):
         self._robot_ik_base = None
 
         self._robot_base = RigidPrim(prim_path=config.prim_path + '/pelvis', name=config.name + '_base')
+        self._robot_right_ankle = RigidPrim(prim_path=config.prim_path + '/right_ankle_link', name=config.name + 'right_ankle')
+        self._robot_left_ankle = RigidPrim(prim_path=config.prim_path + '/left_ankle_link', name=config.name + 'left_ankle')
 
     def post_reset(self):
         super().post_reset()
         self.isaac_robot._process_actuators_cfg()
         if self._gains is not None:
             self.isaac_robot.set_gains(self._gains)
+
+
+    def get_ankle_height(self):
+        return np.min([self._robot_right_ankle.get_world_pose()[0][2], self._robot_left_ankle.get_world_pose()[0][2]])
 
     def get_robot_scale(self):
         return self._robot_scale


### PR DESCRIPTION
- Replace the absolute height with relative height in the observation of locomotion policy, hence the h1 could move on different floors.
- Disable the camera in `h1_house.py` demo to improve FPS.
- Add `/scripts` folder to .gitignore
